### PR TITLE
Implemented fix in index

### DIFF
--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -16,14 +16,14 @@
 				Rationale
 			</th>
 			<th>
-	
+
 			</th>
 		</thead>
-	</tbody>
-	
-	  <% render @posts %>
-      
+	<tbody>
+
+	  <%= render @posts %>
+
 	</tbody>
 </table>
-  
+
 


### PR DESCRIPTION
- Added a `=` for the partial call
- Fixed an HTML syntax error on the index page that showed two closing `</tbody>` calls.
